### PR TITLE
[Feat/FE] 수강 내역의 시간 타입 변경 / 계정 유형에 따른 헤더 nav 권한 부여 구현

### DIFF
--- a/src/components/CourseCard.jsx
+++ b/src/components/CourseCard.jsx
@@ -103,7 +103,7 @@ const CourseCard = ({ id, image, title, description, time, tags }) => {
         <CourseInfo>
           <CourseTitle>{title}</CourseTitle>
           <CourseDescription>{description}</CourseDescription>
-          <CourseTime>{time}</CourseTime>
+          <CourseTime>{time / 60} 분</CourseTime>
           <HorizontalLine />
           <TagContainer>
             {tags && tags.map((tag, index) => (
@@ -121,7 +121,7 @@ CourseCard.propTypes = {
   image: PropTypes.string,
   title: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
-  time: PropTypes.string.isRequired,
+  time: PropTypes.number.isRequired,
   tags: PropTypes.arrayOf(PropTypes.string) 
 };
 

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -8,7 +8,8 @@ import { MdVpnKey } from "react-icons/md";
 import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { userLogin } from "../librarys/login-api.js";
-import { login, selectName, selectIsLoggedIn } from "../redux/userSlice.js";
+import { login, selectName, selectIsLoggedIn, selectIsAdmin } from '../redux/userSlice.js';
+
 
 const HeaderWrapper = styled.header`
   display: flex;
@@ -108,7 +109,7 @@ const Header = () => {
 
   const userName = useSelector(selectName);
   const isLoggedIn = useSelector(selectIsLoggedIn);
-  const isAdmin = useSelector(selectAdmin);
+  const isAdmin = useSelector(selectIsAdmin);
 
   const handleLoginClick = async () => {
     dispatch({ type: "show", payload: "loginModal" });

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -6,10 +6,9 @@ import Modal from "./Modal.jsx";
 import { BsPersonFill } from "react-icons/bs";
 import { MdVpnKey } from "react-icons/md";
 import { useState } from "react";
-import { useDispatch, useSelector} from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { userLogin } from "../librarys/login-api.js";
-import { login, selectName, selectIsLoggedIn } from '../redux/userSlice.js';  
-
+import { login, selectName, selectIsLoggedIn } from "../redux/userSlice.js";
 
 const HeaderWrapper = styled.header`
   display: flex;
@@ -109,6 +108,7 @@ const Header = () => {
 
   const userName = useSelector(selectName);
   const isLoggedIn = useSelector(selectIsLoggedIn);
+  const isAdmin = useSelector(selectAdmin);
 
   const handleLoginClick = async () => {
     dispatch({ type: "show", payload: "loginModal" });
@@ -129,25 +129,40 @@ const Header = () => {
         <MainLink to="/">Re:Hab</MainLink>
       </Logo>
       <Nav>
-        <MainLink to="/register" style={{ marginRight: "50px" }}>
-          운동등록
-        </MainLink>
-        <MainLink to="/" style={{ marginRight: "40px" }}>
-          메인 페이지
-        </MainLink>
-        <MainLink to="/mycourse" style={{ marginRight: "20px" }}>
-          수강내역
-        </MainLink>
-        <Divider />
-        {
-          isLoggedIn ? ( 
-            <span>{userName}</span>
-          ) : (
-            <MainLink to="#" onClick={handleLoginClick}>
-              로그인
+        {isAdmin ? (
+          <>
+            <MainLink to="/register" style={{ marginRight: "50px" }}>
+              운동등록
             </MainLink>
-          )
-        }
+            <MainLink to="/" style={{ marginRight: "40px" }}>
+              메인 페이지
+            </MainLink>
+            <MainLink to="/mycourse" style={{ marginRight: "20px" }}>
+              수강내역
+            </MainLink>
+          </>
+        ) : isLoggedIn ? (
+          <>
+            <MainLink to="/" style={{ marginRight: "40px" }}>
+              메인 페이지
+            </MainLink>
+            <MainLink to="/mycourse" style={{ marginRight: "20px" }}>
+              수강내역
+            </MainLink>
+          </>
+        ) : (
+          <MainLink to="/" style={{ marginRight: "40px" }}>
+            메인 페이지
+          </MainLink>
+        )}
+        <Divider />
+        {isLoggedIn ? (
+          <span>{userName}</span>
+        ) : (
+          <MainLink to="#" onClick={handleLoginClick}>
+            로그인
+          </MainLink>
+        )}
       </Nav>
       <Modal id="loginModal">
         <LoginContainer>

--- a/src/librarys/exercise-api.js
+++ b/src/librarys/exercise-api.js
@@ -5,7 +5,7 @@ const courseList = [
         id: 1,
         title: "거북목 탈출코스",
         description: "이 코스는 목과 어깨의 근육을 이완시켜주는 운동을 포함하고 있습니다.",
-        time: "00:15",
+        time: 900,
         image: CourseImagePlaceholder,
         tags: ["목", "어깨", "앉은 자세"]
     },
@@ -13,7 +13,7 @@ const courseList = [
         id: 2,
         title: "코어 강화 코스",
         description: "코어 근육을 강화하는데 초점을 둔 운동을 학습합니다.",
-        time: "00:15",
+        time: 900,
         image: CourseImagePlaceholder,
         tags: ["팔", "선 자세"]
     },
@@ -21,7 +21,7 @@ const courseList = [
       id: 3,
       title: "하체 강화 코스",
       description: "다리와 엉덩이 근육을 강화하는 운동을 진행합니다.",
-      time: "00:15",
+      time: 900,
       image: CourseImagePlaceholder,
       tags: ["허벅지", "선 자세"]
     },
@@ -29,7 +29,7 @@ const courseList = [
       id: 4,
       title: "유연성 향상 코스",
       description: "몸의 유연성을 높이는 스트레칭 운동을 포함하고 있습니다.",
-      time: "00:15",
+      time: 900,
       image: CourseImagePlaceholder,
       tags: ["어깨", "앉은 자세"]
     },
@@ -38,7 +38,7 @@ const courseList = [
       id: 5,
       title: "유산소 운동 코스",
       description: "심장 건강과 체력 향상을 위한 유산소 운동을 합니다.",
-      time: "00:15",
+      time: 900,
       image: CourseImagePlaceholder,
       tags: ["어깨", "선 자세"]
     },
@@ -46,7 +46,7 @@ const courseList = [
       id: 6,
       title: "근력 운동 코스",
       description: "체중을 이용한 근력 운동을 중점적으로 합니다.",
-      time:  "00:15",
+      time:  900,
       image: CourseImagePlaceholder,
       tags: ["허벅지", "선 자세", "앉은 자세"]
     },
@@ -54,7 +54,7 @@ const courseList = [
       id: 7,
       title: "밸런스 트레이닝",
       description: "몸의 균형 능력을 향상시키기 위한 운동 코스입니다.",
-      time:  "00:15",
+      time:  900,
       image: CourseImagePlaceholder,
       tags: ["어깨", "앉은 자세"]
     },
@@ -62,20 +62,11 @@ const courseList = [
       id: 8,
       title: "포스쳐 교정 코스",
       description: "올바른 자세를 유지하기 위한 교정 운동을 포함하고 있습니다.",
-      time: "총 15분",
+      time: 900,
       image: CourseImagePlaceholder,
       tags: ["목", "선 자세"]
     },
-  ].map(course => {
-    // "00:15" 같은 형태의 문자열을 분리하여 숫자로 변환
-    const [minutes, seconds] = course.time.split(":").map(Number);
-    // 전체 시간을 초 단위로 계산
-    const totalSeconds = minutes * 60 + seconds;
-    return {
-        ...course,
-        time: totalSeconds
-    };
-});
+  ];
 
 function shuffleArray(array) {
     for (let i = array.length - 1; i > 0; i--) {

--- a/src/librarys/exercise-api.js
+++ b/src/librarys/exercise-api.js
@@ -5,7 +5,7 @@ const courseList = [
         id: 1,
         title: "거북목 탈출코스",
         description: "이 코스는 목과 어깨의 근육을 이완시켜주는 운동을 포함하고 있습니다.",
-        time: "총 10분",
+        time: "00:15",
         image: CourseImagePlaceholder,
         tags: ["목", "어깨", "앉은 자세"]
     },
@@ -13,7 +13,7 @@ const courseList = [
         id: 2,
         title: "코어 강화 코스",
         description: "코어 근육을 강화하는데 초점을 둔 운동을 학습합니다.",
-        time: "총 15분",
+        time: "00:15",
         image: CourseImagePlaceholder,
         tags: ["팔", "선 자세"]
     },
@@ -21,7 +21,7 @@ const courseList = [
       id: 3,
       title: "하체 강화 코스",
       description: "다리와 엉덩이 근육을 강화하는 운동을 진행합니다.",
-      time: "총 25분",
+      time: "00:15",
       image: CourseImagePlaceholder,
       tags: ["허벅지", "선 자세"]
     },
@@ -29,7 +29,7 @@ const courseList = [
       id: 4,
       title: "유연성 향상 코스",
       description: "몸의 유연성을 높이는 스트레칭 운동을 포함하고 있습니다.",
-      time: "총 15분",
+      time: "00:15",
       image: CourseImagePlaceholder,
       tags: ["어깨", "앉은 자세"]
     },
@@ -38,7 +38,7 @@ const courseList = [
       id: 5,
       title: "유산소 운동 코스",
       description: "심장 건강과 체력 향상을 위한 유산소 운동을 합니다.",
-      time: "총 30분",
+      time: "00:15",
       image: CourseImagePlaceholder,
       tags: ["어깨", "선 자세"]
     },
@@ -46,7 +46,7 @@ const courseList = [
       id: 6,
       title: "근력 운동 코스",
       description: "체중을 이용한 근력 운동을 중점적으로 합니다.",
-      time: "총 15분",
+      time:  "00:15",
       image: CourseImagePlaceholder,
       tags: ["허벅지", "선 자세", "앉은 자세"]
     },
@@ -54,7 +54,7 @@ const courseList = [
       id: 7,
       title: "밸런스 트레이닝",
       description: "몸의 균형 능력을 향상시키기 위한 운동 코스입니다.",
-      time: "총 20분",
+      time:  "00:15",
       image: CourseImagePlaceholder,
       tags: ["어깨", "앉은 자세"]
     },
@@ -62,7 +62,7 @@ const courseList = [
       id: 8,
       title: "포스쳐 교정 코스",
       description: "올바른 자세를 유지하기 위한 교정 운동을 포함하고 있습니다.",
-      time: "총 15분",
+      time:  "00:15",
       image: CourseImagePlaceholder,
       tags: ["목", "선 자세"]
     },

--- a/src/librarys/exercise-api.js
+++ b/src/librarys/exercise-api.js
@@ -62,11 +62,20 @@ const courseList = [
       id: 8,
       title: "포스쳐 교정 코스",
       description: "올바른 자세를 유지하기 위한 교정 운동을 포함하고 있습니다.",
-      time:  "00:15",
+      time: "총 15분",
       image: CourseImagePlaceholder,
       tags: ["목", "선 자세"]
     },
-];
+  ].map(course => {
+    // "00:15" 같은 형태의 문자열을 분리하여 숫자로 변환
+    const [minutes, seconds] = course.time.split(":").map(Number);
+    // 전체 시간을 초 단위로 계산
+    const totalSeconds = minutes * 60 + seconds;
+    return {
+        ...course,
+        time: totalSeconds
+    };
+});
 
 function shuffleArray(array) {
     for (let i = array.length - 1; i > 0; i--) {


### PR DESCRIPTION
## ☑️ Describe your changes
> 작업 내용을 적어주세요 
- 수강 내역의 시간 타입을 String에서 Number로 변경하였습니다.
- 계정 유형에 따라 헤더의 nav 보이는 것을 다르게 설정하였습니다.
1) 로그인이 안된 상태: 메인 페이지만 보임
2) 일반 유저로 로그인: 메인 페이지와 수강내역만 보임
3) 관리자로 로그인: 모든 링크가 보임

## 📷 Screenshot
1) 관리자 로그인시
![image](https://github.com/ReHab-Web/ReHab-FrontEnd/assets/53892427/fb5b8a25-2fba-4194-9af5-e19426cab57a)
2) 로그인이 되지 않은 상태
![image](https://github.com/ReHab-Web/ReHab-FrontEnd/assets/53892427/cc8dd2da-b1f4-415f-821f-134216bfd636)
3) 일반유저 로그인시
![image](https://github.com/ReHab-Web/ReHab-FrontEnd/assets/53892427/c316aaff-2010-480d-aad8-1ebe90a5b769)


## 🔗 Issue number and link
#22 #18 